### PR TITLE
fix install docs + make docs easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Right now the project is at [phase 0](https://github.com/orgs/omsf/projects/2), where most of the work will be done by creating issues which we will organize on our phase 0 project board.
 
+## Install
+
+See our docs [here](https://openpharmmdflow.readthedocs.io/en/latest/install.html).
+
 ## Manifest
 
 ```

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,7 +22,7 @@ depending on your operating system.
 Then install the package:
 
 .. parsed-literal::
-   python -m pip . --no-deps
+   python -m pip install . --no-deps
 
 Tests
 -----


### PR DESCRIPTION
## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


Fixes #60 