### PR TITLE
Fix solvate() method PACKMOLValueError when box_vectors exist (#92)

### DIFF
--- a/examples/pipeline/Large_Molecule_Pipeline.ipynb
+++ b/examples/pipeline/Large_Molecule_Pipeline.ipynb
@@ -75,7 +75,7 @@
     "        force_field=\"ff14sb_off_impropers_0.0.3.offxml\"\n",
     "    ),\n",
     "    \"simulate_config\": SmallMoleculePipelineSimulateConfig(),\n",
-    "    \"analyize_config\": SmallMoleculePipelineAnalyizeConfig(),\n",
+    "    \"analyze_config\": SmallMoleculePipelineAnalyzeConfig(),\n",
     "    \"solvate_config\": SmallMoleculePipelineSolvateConfig(\n",
     "        nacl_conc=Quantity(0.1, \"mole / liter\"),\n",
     "        padding=Quantity(1.2, \"nanometer\"),\n",
@@ -275,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/examples/pipeline/Small_Molecule_Pipeline.ipynb
+++ b/examples/pipeline/Small_Molecule_Pipeline.ipynb
@@ -73,7 +73,7 @@
     "    ),\n",
     "    \"parameterize_config\": SmallMoleculePipelineParameterizeConfig(),\n",
     "    \"simulate_config\": SmallMoleculePipelineSimulateConfig(),\n",
-    "    \"analyize_config\": SmallMoleculePipelineAnalyizeConfig(),\n",
+    "    \"analyze_config\": SmallMoleculePipelineAnalyzeConfig(),\n",
     "}\n",
     "sm_config = SmallMoleculePipelineConfig(**settings)"
    ]
@@ -255,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/openpharmmdflow/pipeline/sm/__init__.py
+++ b/openpharmmdflow/pipeline/sm/__init__.py
@@ -1,0 +1,3 @@
+from .utils import write_residue_names
+
+__all__ = ["write_residue_names"]

--- a/openpharmmdflow/pipeline/sm/pipeline.py
+++ b/openpharmmdflow/pipeline/sm/pipeline.py
@@ -117,9 +117,7 @@ class SmallMoleculePipeline:
         # If the topology already has box vectors defined (from pack step),
         # we must set padding=None to avoid PACKMOLValueError
         padding = (
-            0
-            if self.topology.box_vectors is not None
-            else self.solvate_config.padding
+            0 if self.topology.box_vectors is not None else self.solvate_config.padding
         )
 
         self.solvated_topology = solvate_topology(

--- a/openpharmmdflow/pipeline/sm/pipeline.py
+++ b/openpharmmdflow/pipeline/sm/pipeline.py
@@ -14,6 +14,7 @@ from openpharmmdflow.io.load import load_file
 from openpharmmdflow.pipeline.sm.pipeline_settings import SmallMoleculePipelineConfig
 from openpharmmdflow.pipeline.sm.simulation import create_simulation
 from openpharmmdflow.pipeline.sm.simulation import run_simulation
+from openpharmmdflow.pipeline.sm.utils import write_residue_names
 
 # TODO: Use snakemake to manage pipeline?
 # TODO: Use decorators for DAG/deps?
@@ -35,6 +36,7 @@ class SmallMoleculePipeline:
         self.parameterize_config = config.parameterize_config
         self.bespoke_ff = None
         self.simulate_config = config.simulate_config
+        self.analyze_config = config.analyze_config
 
     def load(self):
         # TODO raise error if duplcate name
@@ -92,12 +94,38 @@ class SmallMoleculePipeline:
                 box_shape=self.pack_config.box_shape,
             )
 
+        # Apply residue names immediately after packing (BEFORE solvation)
+        # This ensures water molecules get UNK residue names during solvation
+        # Automatically generate residue names from molecule names in config
+        molecule_to_resname = {}
+        for mol_name in self.pack_config.molecule_names:
+            # Use first 3 characters of molecule name as residue name (PDB standard)
+            # Convert to uppercase for consistency
+            residue_name = mol_name[:3].upper()
+            molecule_to_resname[mol_name] = residue_name
+
+        write_residue_names(self, molecule_to_resname)
+
     def solvate(self):
+        # Check if solvate configuration is provided
+        if self.solvate_config is None:
+            raise ValueError(
+                "solvate_config must be provided to use the solvate() method"
+            )
+
         # Solvate the box
+        # If the topology already has box vectors defined (from pack step),
+        # we must set padding=None to avoid PACKMOLValueError
+        padding = (
+            None
+            if self.topology.box_vectors is not None
+            else self.solvate_config.padding
+        )
+
         self.solvated_topology = solvate_topology(
             self.topology,
             nacl_conc=self.solvate_config.nacl_conc,
-            padding=self.solvate_config.padding,
+            padding=padding,
             box_shape=self.solvate_config.box_shape,
             target_density=self.solvate_config.target_density,
             tolerance=self.solvate_config.tolerance,
@@ -127,6 +155,14 @@ class SmallMoleculePipeline:
         self.n_chlorine_ion = len(
             [m for m in self.solvated_topology.molecules if m.to_smiles() == "[Cl-]"]
         )
+
+        # Apply residue names to water and ions added during solvation
+        # The write_residue_names function will automatically detect and name:
+        # - Water molecules as "WAT"
+        # - Sodium ions as "SOD"
+        # - Chloride ions as "CLA"
+        # based on their SMILES patterns
+        write_residue_names(self)
 
     def parameterize(self):
         # TODO test to make sure we use the FF we expect to use
@@ -172,9 +208,39 @@ class SmallMoleculePipeline:
             self.interchange = self.components_intrcg
 
     def simulate(self):
-        self.simulation = create_simulation(self.simulate_config, self.interchange)
-        run_simulation(self.simulate_config, self.simulation)
+        """Run MD simulation with enhanced trajectory output and performance monitoring"""
+        print("🚀 Setting up MD simulation...")
 
-    def analyize(self):
+        # Create simulation with optimized reporters
+        self.simulation = create_simulation(self.simulate_config, self.interchange)
+
+        # Run simulation and capture performance metrics
+        elapsed_time, ns_per_day = run_simulation(self.simulate_config, self.simulation)
+
+        # Store performance metrics
+        self.simulation_performance = {
+            "elapsed_time": elapsed_time,
+            "ns_per_day": ns_per_day,
+            "n_steps": self.simulate_config.n_steps,
+            "timestep_fs": self.simulate_config.time_step_fs,
+            "total_atoms": (
+                self.interchange.topology.n_atoms
+                if hasattr(self.interchange.topology, "n_atoms")
+                else 0
+            ),
+        }
+
+        print(f"✅ Simulation completed successfully!")
+        print(f"   Performance: {ns_per_day:.2f} ns/day")
+        print(f"   Output directory: {self.simulate_config.output_directory}")
+
+    def get_simulation_performance(self):
+        """Get simulation performance metrics"""
+        if hasattr(self, "simulation_performance"):
+            return self.simulation_performance
+        else:
+            return None
+
+    def analyze(self):
         # run analysis here
         pass

--- a/openpharmmdflow/pipeline/sm/pipeline.py
+++ b/openpharmmdflow/pipeline/sm/pipeline.py
@@ -117,7 +117,7 @@ class SmallMoleculePipeline:
         # If the topology already has box vectors defined (from pack step),
         # we must set padding=None to avoid PACKMOLValueError
         padding = (
-            None
+            0
             if self.topology.box_vectors is not None
             else self.solvate_config.padding
         )

--- a/openpharmmdflow/pipeline/sm/pipeline_settings.py
+++ b/openpharmmdflow/pipeline/sm/pipeline_settings.py
@@ -88,15 +88,34 @@ class SmallMoleculePipelineParameterizeConfig(BaseModel):
 
 
 class SmallMoleculePipelineSimulateConfig(BaseModel):
-    pdb_stride: int = 500
-    trajectory_name: str = "trajectory.pdb"
+    # Basic simulation parameters
+    save_frequency_steps: int = 500
+    save_data_frequency_steps: int = 10
+    simulation_chunk_step_size: int = (
+        250  # Controls console output frequency and simulation loop chunking
+    )
+    n_steps: int = 5000
     temp_k: float = 300
     time_step_fs: int = 1
     pressure_bar: float = 1
-    n_steps: int = 5000
+    ensemble: str = "npt"
+
+    # Output directory and file configuration
+    output_directory: str = "."
+
+    # Enhanced trajectory options for optimized output
+    trajectory_format: str = "dcd"  # Primary format: 'dcd', 'h5', 'pdb'
+    enable_hdf5: bool = True  # Try to enable HDF5 if MDTraj available
+    pdb_frequency_multiplier: int = 100  # PDB saved every N * save_frequency_steps
+    checkpoint_frequency_multiplier: int = (
+        10  # Checkpoint every N * save_frequency_steps
+    )
+
+    # Legacy compatibility field
+    trajectory_name: str = "trajectory.pdb"
 
 
-class SmallMoleculePipelineAnalyizeConfig(BaseModel):
+class SmallMoleculePipelineAnalyzeConfig(BaseModel):
     pass
 
 
@@ -113,7 +132,7 @@ class SmallMoleculePipelineConfig(BaseModel):
     solvate_config: SmallMoleculePipelineSolvateConfig | None
     parameterize_config: SmallMoleculePipelineParameterizeConfig
     simulate_config: SmallMoleculePipelineSimulateConfig
-    analyize_config: SmallMoleculePipelineAnalyizeConfig
+    analyze_config: SmallMoleculePipelineAnalyzeConfig
 
     class Config:
         arbitrary_types_allowed = True

--- a/openpharmmdflow/pipeline/sm/simulation.py
+++ b/openpharmmdflow/pipeline/sm/simulation.py
@@ -1,8 +1,10 @@
 """
-Wrapper for running openmm simulation
+OpenMM simulation wrapper following OpenMM best practices with optimized trajectory formats
 """
 
+import os
 import time
+from typing import Union
 
 import numpy as np
 import openmm
@@ -11,73 +13,289 @@ import openmm.unit
 from openff.interchange import Interchange
 
 
-# TODO: Resume simulation
 def create_simulation(
     simulate_config,
     interchange: Interchange,
 ) -> openmm.app.Simulation:
-    pdb_stride = simulate_config.pdb_stride
-    trajectory_name = simulate_config.trajectory_name
+    """Create OpenMM simulation following standard patterns with optimized reporters"""
+
+    # Extract configuration parameters
+    save_frequency_steps = simulate_config.save_frequency_steps
+    save_data_frequency_steps = simulate_config.save_data_frequency_steps
+    simulation_chunk_step_size = getattr(
+        simulate_config, "simulation_chunk_step_size", save_data_frequency_steps
+    )
     temp = simulate_config.temp_k
     time_step_fs = simulate_config.time_step_fs
     pressure_bar = simulate_config.pressure_bar
+    output_directory = simulate_config.output_directory
 
-    integrator = openmm.LangevinIntegrator(
+    # Ensure output directory exists
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Use LangevinMiddleIntegrator (more stable than LangevinIntegrator)
+    integrator = openmm.LangevinMiddleIntegrator(
         temp * openmm.unit.kelvin,
-        time_step_fs / openmm.unit.picosecond,
+        time_step_fs / openmm.unit.picosecond,  # Friction coefficient
         time_step_fs * openmm.unit.femtoseconds,
     )
 
-    barostat = openmm.MonteCarloBarostat(
-        pressure_bar * openmm.unit.bar, temp * openmm.unit.kelvin, 25
-    )
-
+    # Create simulation from interchange
     simulation = interchange.to_openmm_simulation(
         combine_nonbonded_forces=True,
         integrator=integrator,
     )
 
-    simulation.system.addForce(barostat)
+    # Add barostat for NPT ensemble
+    ensemble = getattr(simulate_config, "ensemble", "npt")
+    if ensemble.lower() == "npt":
+        barostat = openmm.MonteCarloBarostat(
+            pressure_bar * openmm.unit.bar,
+            temp * openmm.unit.kelvin,
+            25,  # Frequency of volume moves
+        )
+        simulation.system.addForce(barostat)
 
-    # https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#why-does-it-ignore-changes-i-make-to-a-system-or-force
-    simulation.context.reinitialize(preserveState=True)
-    print("start minimize")
-    # https://github.com/openmm/openmm/issues/3736#issuecomment-1217250635
-    simulation.minimizeEnergy()
-    print("end minimize")
-    simulation.context.setVelocitiesToTemperature(temp * openmm.unit.kelvin)
-    simulation.context.computeVirtualSites()
+        # Required after adding forces
+        simulation.context.reinitialize(preserveState=True)
 
-    pdb_reporter = openmm.app.PDBReporter(trajectory_name, pdb_stride)
-    state_data_reporter = openmm.app.StateDataReporter(
-        "data.csv",
-        10,
-        step=True,
-        potentialEnergy=True,
-        temperature=True,
-        density=True,
-    )
-    simulation.reporters.append(pdb_reporter)
-    simulation.reporters.append(state_data_reporter)
+    # Set up optimized trajectory reporters
+    setup_trajectory_reporters(simulation, simulate_config, output_directory)
 
     return simulation
+
+
+def setup_trajectory_reporters(simulation, simulate_config, output_directory):
+    """Set up optimized trajectory reporters for large simulations"""
+    save_frequency_steps = simulate_config.save_frequency_steps
+    save_data_frequency_steps = simulate_config.save_data_frequency_steps
+    simulation_chunk_step_size = getattr(
+        simulate_config, "simulation_chunk_step_size", save_data_frequency_steps
+    )
+
+    print(f"📁 Setting up trajectory reporters in: {output_directory}")
+
+    # 1. DCD Reporter (Primary trajectory - binary, compact)
+    dcd_file = os.path.join(output_directory, "trajectory.dcd")
+    dcd_reporter = openmm.app.DCDReporter(
+        dcd_file, save_frequency_steps, enforcePeriodicBox=True
+    )
+    simulation.reporters.append(dcd_reporter)
+    print(f"   🔸 DCD trajectory: {dcd_file} (every {save_frequency_steps} steps)")
+
+    # 2. State Data Reporter (Thermodynamic data - CSV format)
+    data_file = os.path.join(output_directory, "simulation_data.csv")
+    state_reporter = openmm.app.StateDataReporter(
+        data_file,
+        save_data_frequency_steps,
+        step=True,
+        time=True,
+        potentialEnergy=True,
+        kineticEnergy=True,
+        totalEnergy=True,
+        temperature=True,
+        volume=True,
+        density=True,
+        speed=True,  # Performance monitoring
+        separator=",",
+    )
+    simulation.reporters.append(state_reporter)
+    print(
+        f"   🔸 Thermodynamic data: {data_file} (every {save_data_frequency_steps} steps)"
+    )
+
+    # 3. Checkpoint Reporter (For resuming simulations)
+    checkpoint_file = os.path.join(output_directory, "checkpoint.chk")
+    checkpoint_multiplier = getattr(
+        simulate_config, "checkpoint_frequency_multiplier", 10
+    )
+    checkpoint_frequency = save_frequency_steps * checkpoint_multiplier
+    checkpoint_reporter = openmm.app.CheckpointReporter(
+        checkpoint_file, checkpoint_frequency
+    )
+    simulation.reporters.append(checkpoint_reporter)
+    print(f"   🔸 Checkpoint: {checkpoint_file} (every {checkpoint_frequency} steps)")
+
+    # 4. HDF5 Reporter (Optional - if MDTraj available, best for analysis)
+    try:
+        from mdtraj.reporters import HDF5Reporter
+
+        h5_file = os.path.join(output_directory, "trajectory.h5")
+
+        # Check if HDF5 file exists (indicates resumption)
+        if os.path.exists(h5_file):
+            print(
+                f"   ⚠️ HDF5 trajectory exists, skipping to avoid file lock: {h5_file}"
+            )
+        else:
+            h5_reporter = HDF5Reporter(
+                h5_file,
+                save_frequency_steps,
+                coordinates=True,
+                time=True,
+                cell=True,
+                potentialEnergy=True,
+                temperature=True,
+            )
+            simulation.reporters.append(h5_reporter)
+            print(f"   ✅ HDF5 trajectory: {h5_file} (analysis-optimized)")
+    except ImportError:
+        print("   ⚠️ MDTraj not available - HDF5 trajectory disabled")
+        print("   💡 Install with: micromamba install -c conda-forge mdtraj")
+
+    # 5. PDB Reporter (Sparse frames for visualization only)
+    pdb_file = os.path.join(output_directory, "trajectory_vis.pdb")
+
+    # Use pdb_frequency_multiplier if available, otherwise default to 100
+    pdb_multiplier = getattr(simulate_config, "pdb_frequency_multiplier", 100)
+    pdb_frequency = save_frequency_steps * pdb_multiplier
+
+    pdb_reporter = openmm.app.PDBReporter(
+        pdb_file, pdb_frequency, enforcePeriodicBox=True
+    )
+    simulation.reporters.append(pdb_reporter)
+    print(f"   🔸 PDB visualization: {pdb_file} (every {pdb_frequency} steps)")
 
 
 def run_simulation(
     simulate_config,
     simulation: openmm.app.Simulation,
+    resume: bool = False,
 ):
+    """Run simulation following OpenMM best practices with improved monitoring"""
     n_steps = simulate_config.n_steps
-    print("Starting simulation")
-    start_time = time.process_time()
+    save_data_frequency_steps = simulate_config.save_data_frequency_steps
+    simulation_chunk_step_size = getattr(
+        simulate_config, "simulation_chunk_step_size", save_data_frequency_steps
+    )
+    temp_k = simulate_config.temp_k
+    time_step_fs = simulate_config.time_step_fs
 
-    print("Step, volume (nm^3)")
+    print("🚀 Starting simulation setup...")
+    start_time = time.time()
+    if not resume:
+        # Energy minimization
+        print("⚡ Minimizing energy...")
+        try:
+            simulation.minimizeEnergy(maxIterations=1000)
+            minimized_state = simulation.context.getState(getEnergy=True)
+            pe_initial = minimized_state.getPotentialEnergy().value_in_unit(
+                openmm.unit.kilojoules_per_mole
+            )
+            print(f"✅ Energy minimization completed: PE = {pe_initial:.1f} kJ/mol")
+        except Exception as e:
+            print(f"⚠️ Energy minimization failed: {e}")
+            print("   Continuing with original structure...")
 
-    for step in range(n_steps):
-        simulation.step(1)
-        if step % 500 == 0:
-            box_vectors = simulation.context.getState().getPeriodicBoxVectors()
-            print(step, np.linalg.det(box_vectors._value).round(3))
+        # Set initial velocities
+        simulation.context.setVelocitiesToTemperature(temp_k * openmm.unit.kelvin)
+        print(f"🌡️ Initial velocities set to {temp_k} K")
 
-    end_time = time.process_time()
-    print(f"Elapsed time: {(end_time - start_time):.2f} seconds")
+    # Compute virtual sites if present
+    simulation.context.computeVirtualSites()
+
+    print(f"🏃 Starting MD simulation: {n_steps:,} steps")
+    print(f"   Timestep: {time_step_fs} fs")
+    print(f"   Total time: {n_steps * time_step_fs / 1e6:.2f} ns")
+    print()
+    print("Step,      Time (ps), Volume (nm³), Temperature (K), PE (kJ/mol)")
+    print("-" * 65)
+
+    # Standard OpenMM simulation loop - run in chunks for monitoring
+    chunk_size = min(
+        simulation_chunk_step_size, 50000
+    )  # Use new parameter for chunk size
+
+    for start_step in range(0, n_steps, chunk_size):
+        end_step = min(start_step + chunk_size, n_steps)
+        steps_to_run = end_step - start_step
+
+        try:
+            # Run chunk of simulation
+            simulation.step(steps_to_run)
+
+            # Progress monitoring at configured intervals using new parameter
+            if start_step % simulation_chunk_step_size == 0 or end_step == n_steps:
+                state = simulation.context.getState(getEnergy=True)
+
+                # Extract state information
+                step_num = end_step
+                time_ps = step_num * time_step_fs / 1000.0
+
+                # Get box volume
+                box_vectors = state.getPeriodicBoxVectors(asNumpy=True)
+                volume_nm3 = np.linalg.det(
+                    box_vectors.value_in_unit(openmm.unit.nanometer)
+                )
+
+                # Get energies
+                pe = state.getPotentialEnergy().value_in_unit(
+                    openmm.unit.kilojoules_per_mole
+                )
+
+                # Calculate temperature from integrator (most reliable method)
+                # This avoids unit conversion issues with kinetic energy
+                temp_k_current = simulation.integrator.getTemperature().value_in_unit(
+                    openmm.unit.kelvin
+                )
+
+                print(
+                    f"{step_num:8d}, {time_ps:10.2f}, {volume_nm3:10.3f}, {temp_k_current:12.1f}, {pe:12.1f}"
+                )
+
+        except Exception as e:
+            print(f"❌ Simulation error at step {start_step}: {e}")
+
+            # Save emergency checkpoint
+            output_dir = getattr(simulate_config, "output_directory", ".")
+            emergency_checkpoint = os.path.join(
+                output_dir, f"emergency_checkpoint_{start_step}.chk"
+            )
+            simulation.saveCheckpoint(emergency_checkpoint)
+            print(f"💾 Emergency checkpoint saved: {emergency_checkpoint}")
+
+            raise
+
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+
+    print("\n" + "=" * 65)
+    print("🎉 Simulation completed successfully!")
+    print(f"⏱️ Total time: {elapsed_time:.2f} seconds ({elapsed_time/3600:.2f} hours)")
+    print(f"⚡ Performance: {n_steps/elapsed_time:.0f} steps/second")
+
+    # Calculate simulation rate metrics
+    simulated_time_ns = n_steps * time_step_fs / 1e6
+    ns_per_day = simulated_time_ns * 86400 / elapsed_time
+    print(f"📊 Sampling rate: {ns_per_day:.2f} ns/day")
+    print(f"📈 Simulated time: {simulated_time_ns:.2f} ns")
+
+    return elapsed_time, ns_per_day
+
+
+def resume_simulation(
+    simulate_config,
+    simulation: openmm.app.Simulation,
+    checkpoint_file: str | None = None,
+):
+    """Resume simulation from checkpoint"""
+    output_dir = getattr(simulate_config, "output_directory", ".")
+
+    if checkpoint_file is None:
+        checkpoint_file = os.path.join(output_dir, "checkpoint.chk")
+
+    if not os.path.exists(checkpoint_file):
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_file}")
+
+    print(f"🔄 Resuming simulation from: {checkpoint_file}")
+
+    # Load checkpoint
+    simulation.loadCheckpoint(checkpoint_file)
+
+    # Get current state info
+    state = simulation.context.getState(getEnergy=True)
+    pe = state.getPotentialEnergy()
+    print(f"   Resumed state: PE = {pe}")
+
+    # Continue simulation
+    run_simulation(simulate_config, simulation, resume=True)

--- a/openpharmmdflow/pipeline/sm/utils.py
+++ b/openpharmmdflow/pipeline/sm/utils.py
@@ -1,0 +1,91 @@
+"""
+Utility functions for Small Molecule Pipeline
+"""
+
+
+def _cast_topology_positions_to_float64(topology):
+    # Cast all conformer coordinates to float64 for RDKit compatibility
+    # This is a workaround for a known RDKit bug with float32 coordinates
+    # TODO: Figure why topology positions are float32 in the first place
+    for molecule in topology.molecules:
+        for i, conformer in enumerate(molecule._conformers):
+            molecule._conformers[i] = conformer.astype("float64")
+    return topology
+
+
+def write_residue_names(pipeline, molecule_to_resname=None):
+    """
+    Assign residue names to atoms in molecules for proper PDB output.
+
+    Parameters
+    ----------
+    pipeline : SmallMoleculePipeline
+        The pipeline object with loaded topology (works with both topology and solvated_topology)
+    molecule_to_resname : dict, optional
+        Mapping of molecule names to residue names. If None, uses first 3 letters uppercase.
+        Standard names: water -> "WAT", sodium -> "NA", chloride -> "CL"
+
+    Example
+    -------
+    molecule_to_resname = {
+        "ibuprofen": "IBU",
+        "CAP": "CAP",
+    }
+    write_residue_names(smp, molecule_to_resname)
+    """
+    if molecule_to_resname is None:
+        molecule_to_resname = {}
+
+    # This is a workaround for a known RDKit bug with float32 coordinates
+    pipeline.topology = _cast_topology_positions_to_float64(pipeline.topology)
+
+    topologies_to_fix = ["topology", "solvated_topology"]
+    for topo_name in topologies_to_fix:
+        if not hasattr(pipeline, topo_name):
+            continue
+        # Use solvated_topology if available, otherwise topology
+        topology = getattr(pipeline, topo_name, pipeline.topology)
+
+        # Print loaded molecule names to confirm
+        print("Assigning residue names to molecules:")
+
+        # Assign residue names to atoms
+        for molecule in topology.molecules:
+            # print(f"  Processing molecule: {molecule.name}")
+            # Get SMILES to identify molecule type
+            smiles = molecule.to_smiles()
+
+            # Default residue names for common molecules
+            default_names = {
+                "[H][O][H]": "WAT",  # Water
+                "[Na+]": "NA",  # Sodium ion
+                "[Cl-]": "CL",  # Chloride ion
+            }
+
+            # Determine residue name
+            if molecule.name in molecule_to_resname:
+                resname = molecule_to_resname[molecule.name]
+            elif smiles in default_names:
+                resname = default_names[smiles]
+            else:
+                resname = molecule.name[:3].upper() if molecule.name else "UNK"
+
+            # Assign to all atoms in the molecule
+            for atom in molecule.atoms:
+                if not hasattr(atom, "metadata") or atom.metadata is None:
+                    atom.metadata = {}
+                atom.metadata["residue_name"] = resname
+
+            # print(f"  {molecule.name} (SMILES: {smiles}) -> {resname}")
+            setattr(
+                pipeline, topo_name, topology
+            )  # Update topology in pipeline if needed
+        # Verify assignment worked
+        molecule_list = list(getattr(pipeline, topo_name).molecules)
+        print(f"\nVerification (showing first 3 molecules):")
+        for i, molecule in enumerate(molecule_list[:3]):
+            first_atom_resname = molecule.atoms[0].metadata.get("residue_name", "NONE")
+            print(
+                f"  Molecule {i}: {molecule.name} -> residue_name = {first_atom_resname}"
+            )
+    print("\nResidue name assignment complete.\n")

--- a/openpharmmdflow/tests/pipeline/solvate_fix_test.py
+++ b/openpharmmdflow/tests/pipeline/solvate_fix_test.py
@@ -1,0 +1,120 @@
+"""
+Test for the solvate box_vectors/padding fix
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openpharmmdflow.pipeline.sm.pipeline import SmallMoleculePipeline
+from openpharmmdflow.pipeline.sm.pipeline_settings import *
+
+
+def test_solvate_with_predefined_box_vectors():
+    """Test that solvate method works when topology has box_vectors from pack step"""
+
+    # Create a minimal SDF file for testing
+    test_sdf_content = """
+  Mrv2411 01010000002D
+
+  1  0  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test molecule file
+        mol_path = Path(tmpdir) / "test_mol.sdf"
+        mol_path.write_text(test_sdf_content)
+
+        # Set up pipeline configuration
+        settings = {
+            "work_dir": tmpdir,
+            "inputs": [
+                SmallMoleculePipelineInputConfig(name="test_mol", path=mol_path)
+            ],
+            "pack_config": SmallMoleculePipelinePackConfig(
+                molecule_names=["test_mol"],
+                number_of_copies=[1],
+                target_density=0.1,
+            ),
+            "parameterize_config": SmallMoleculePipelineParameterizeConfig(),
+            "simulate_config": SmallMoleculePipelineSimulateConfig(),
+            "analyze_config": SmallMoleculePipelineAnalyzeConfig(),
+            "solvate_config": SmallMoleculePipelineSolvateConfig(
+                nacl_conc=Quantity(0.00, "mole / liter"),
+                padding=Quantity(1.2, "nanometer"),  # This should get set to None
+                box_shape=UNIT_CUBE,
+                target_density=Quantity(0.9, "gram / milliliter"),
+                tolerance=Quantity(2.0, "angstrom"),
+            ),
+        }
+
+        sm_config = SmallMoleculePipelineConfig(**settings)
+
+        # Initialize and run pipeline
+        smp = SmallMoleculePipeline(sm_config)
+        smp.load()
+        smp.pack()
+
+        # Verify that topology has box_vectors after packing
+        assert (
+            smp.topology.box_vectors is not None
+        ), "Topology should have box_vectors after packing"
+
+        # This should not raise PACKMOLValueError anymore
+        smp.solvate()
+
+        # Verify solvated topology was created
+        assert hasattr(
+            smp, "solvated_topology"
+        ), "Should have solvated_topology after solvate()"
+        assert smp.solvated_topology is not None, "solvated_topology should not be None"
+
+
+def test_solvate_without_config_raises_error():
+    """Test that solvate method raises error when solvate_config is None"""
+
+    test_sdf_content = """
+  Mrv2411 01010000002D
+
+  1  0  0  0  0  0            999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test molecule file
+        mol_path = Path(tmpdir) / "test_mol.sdf"
+        mol_path.write_text(test_sdf_content)
+
+        # Set up pipeline configuration WITHOUT solvate_config
+        settings = {
+            "work_dir": tmpdir,
+            "inputs": [
+                SmallMoleculePipelineInputConfig(name="test_mol", path=mol_path)
+            ],
+            "pack_config": SmallMoleculePipelinePackConfig(
+                molecule_names=["test_mol"],
+                number_of_copies=[1],
+                target_density=0.1,
+            ),
+            "parameterize_config": SmallMoleculePipelineParameterizeConfig(),
+            "simulate_config": SmallMoleculePipelineSimulateConfig(),
+            "analyze_config": SmallMoleculePipelineAnalyzeConfig(),
+            "solvate_config": None,  # Explicitly set to None
+        }
+
+        sm_config = SmallMoleculePipelineConfig(**settings)
+
+        # Initialize and run pipeline
+        smp = SmallMoleculePipeline(sm_config)
+        smp.load()
+        smp.pack()
+
+        # This should raise ValueError
+        with pytest.raises(ValueError, match="solvate_config must be provided"):
+            smp.solvate()

--- a/openpharmmdflow/tests/pipeline/solvate_fix_test.py
+++ b/openpharmmdflow/tests/pipeline/solvate_fix_test.py
@@ -37,8 +37,8 @@ $$$$
             ],
             "pack_config": SmallMoleculePipelinePackConfig(
                 molecule_names=["test_mol"],
-                number_of_copies=[1],
-                target_density=0.1,
+                number_of_copies=[10],
+                target_density=0.01,
             ),
             "parameterize_config": SmallMoleculePipelineParameterizeConfig(),
             "simulate_config": SmallMoleculePipelineSimulateConfig(),
@@ -47,7 +47,7 @@ $$$$
                 nacl_conc=Quantity(0.00, "mole / liter"),
                 padding=Quantity(1.2, "nanometer"),  # This should get set to None
                 box_shape=UNIT_CUBE,
-                target_density=Quantity(0.9, "gram / milliliter"),
+                target_density=Quantity(2.0, "gram / milliliter"),
                 tolerance=Quantity(2.0, "angstrom"),
             ),
         }


### PR DESCRIPTION
* Fix PACKMOLValueError in SmallMoleculePipeline.solvate()

- Fixed incompatible inputs error when topology has defined box_vectors and padding is also specified in solvate_topology call
- When topology.box_vectors is not None (from pack step), automatically set padding=None to avoid PACKMOLValueError
- Added validation to ensure solvate_config is provided before calling solvate()
- Added comprehensive tests for the fix including edge cases
- Resolves issue where pipeline would fail after pack() + solvate() sequence

The OpenFF Interchange library requires either box_vectors OR padding, but not both. Since pack() creates box_vectors, solvate() must use padding=None to avoid conflicts.

Fixes: PACKMOLValueError: Incompatible inputs: input topology has defined box vectors and a solvent padding distance was also specified.

* Add residue name utility function

- Add write_residue_names() utility function for proper PDB output
- Function assigns residue names to atom metadata for correct PDB residue naming
- Supports custom molecule_to_resname mapping or automatic naming
- Useful for CAP/IBU simulations with proper residue identification

* Improve residue name assignment for solvated systems

- Updated write_residue_names() to handle solvated_topology
- Automatically assigns standard residue names: WAT, SOD, CLA
- Works with both topology and solvated_topology
- Identifies molecules by SMILES for robust assignment
- Provides better verification output

This ensures proper PDB output for both neat and solvated systems.

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* fixing float32 incompatibility in RDKit to_smiles method

* fixing bug with hardcoded stride and log file frequency

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Add simulation_chunk_step_size parameter for better console output control

- Added simulation_chunk_step_size parameter to SmallMoleculePipelineSimulateConfig with default 250
- Updated simulation loop to use chunk size for console output frequency
- Allows independent control of console output vs data collection frequency
- Improves user experience by reducing console spam during long simulations

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Enhanced pipeline simulation with performance monitoring and residue naming

- Added performance metrics tracking in simulate() method
- Integrated residue naming functionality for better PDB output
- Added analyze_config support and fixed typo in analyze() method
- Enhanced simulation output with trajectory information
- Added get_simulation_performance() method for accessing metrics

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* fixing typo in test case

* the default value is set to . in the pydantic dataclass for SimulateConfig. Therefore removing redundant code and increasing conssitency

* fixing the bug to let the friction coefficient scale with timestep. Reverting back to original code

* suggesting to use micromamba instead of pip for installing mdtraj

* fixing residue symbol assignment for sodium and chloride ions

* avoiding setting of temperature during resume

* fixing typo in analyize_config in test case

* fix typo in classname

* Rename test

* fix typo in dict name

---------


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
